### PR TITLE
Minor fix to package imports in widget

### DIFF
--- a/src/napari_dinosim/_widget.py
+++ b/src/napari_dinosim/_widget.py
@@ -12,6 +12,8 @@ from magicgui.widgets import (
     create_widget,
     FloatSpinBox,
 )
+
+import napari
 from napari.layers import Image, Points
 from napari.qt import thread_worker
 from qtpy.QtWidgets import (
@@ -22,7 +24,7 @@ from qtpy.QtWidgets import (
     QLabel,
     QVBoxLayout,
 )
-from torch import cuda, device, float32, hub, tensor
+from torch import cuda, device, float32, hub, tensor, mps
 
 from .dinoSim_pipeline import DinoSim_pipeline
 from .utils import gaussian_kernel, get_img_processing_f, torch_convolve


### PR DESCRIPTION
Hi @AAitorG,

This PR fixes this super tiny bugs which were laying around (some module import errors).
The `mps` import did not allow the widget to open, and the `napari` import was raised by my linter for one of the type hint calls.

GTG from my side!