### PR TITLE
Minor update to map expected scale factor from stored embeddings filepath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pdf
 *.svg
 *.tif
+*.pt
 .cursorrules
 private_tests
 

--- a/src/napari_dinosim/_widget.py
+++ b/src/napari_dinosim/_widget.py
@@ -354,7 +354,7 @@ class DINOSim_widget(Container):
             value="Auto Precompute:", name="subsection_label"
         )
         self.auto_precompute_checkbox = CheckBox(
-            value=False,
+            value=True,
             text="",
             tooltip="Automatically precompute embeddings when image/crop size changes",
         )
@@ -374,6 +374,9 @@ class DINOSim_widget(Container):
             tooltip="Manually trigger embedding precomputation",
         )
         self.manual_precompute_btn.changed.connect(self._manual_precompute)
+        self.manual_precompute_btn.enabled = (
+            False  # Initially disabled since auto is on
+        )
 
         # Save/Load embeddings buttons
         self._save_emb_btn = PushButton(

--- a/src/napari_dinosim/_widget.py
+++ b/src/napari_dinosim/_widget.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from typing import Optional
 
 import numpy as np
@@ -353,7 +354,7 @@ class DINOSim_widget(Container):
             value="Auto Precompute:", name="subsection_label"
         )
         self.auto_precompute_checkbox = CheckBox(
-            value=True,
+            value=False,
             text="",
             tooltip="Automatically precompute embeddings when image/crop size changes",
         )
@@ -373,9 +374,6 @@ class DINOSim_widget(Container):
             tooltip="Manually trigger embedding precomputation",
         )
         self.manual_precompute_btn.changed.connect(self._manual_precompute)
-        self.manual_precompute_btn.enabled = (
-            False  # Initially disabled since auto is on
-        )
 
         # Save/Load embeddings buttons
         self._save_emb_btn = PushButton(
@@ -1184,6 +1182,14 @@ class DINOSim_widget(Container):
                 self.pipeline_engine.load_embeddings(filepath)
                 # Update status indicator
                 self._set_embedding_status("ready")
+
+                # Extract scale factor from filename and update the SpinBox.
+                match = re.search(r"_x([0-9.]+)\.pt$", filepath)
+                if match:
+                    try:
+                        self.scale_factor_selector.value = float(match.group(1))
+                    except ValueError:  # Do not update the scale factor if the value does not match.
+                        pass
 
                 # Update references if they exist
                 if (


### PR DESCRIPTION
Hi @AAitorG,

I love the nice design of storing and loading precomputed embeddings now. Thanks for the work!

I spotted a tiny detail and maybe you agree (?) - when I load back the precomputed embedding stored via the widget, it does not update the scale factor (i.e. leaves it to default `1.0`). Since you script the scale factor quite nicely in the stored filename, I decided to make the widget look for it while loading embeddings, if available, otherwise stick to the defaults.

GTG from my side! Let me know how what do you think about it!

PS: The imports would probably be broken here. Would make sense to take a look at https://github.com/AAitorG/napari-dinoSim/pull/6 first before discussing this!